### PR TITLE
always use object as dtype when creating a string series

### DIFF
--- a/behave_pandas/dtypes.py
+++ b/behave_pandas/dtypes.py
@@ -24,7 +24,7 @@ VALID_DATETIME_DTYPES = {
 
 VALID_OBJECT_DTYPES = {
     "object": object,
-    'str': str,
+    'str': object,
 }
 
 VALID_DTYPES = {


### PR DESCRIPTION
The behaviour of 

```python
In [3]: object_data = ['silly walks', np.nan, 'dead parrot']
In [5]: pd.Series(object_data, dtype=str)
``` 
as changed in pandas 0.23.
it used to return:
```python
Out[5]:
0    silly walks
1            NaN
2    dead parrot
dtype: object
```
but now returns
```python
Out[5]:
0    silly walks
1            nan
2    dead parrot
dtype: object
```

using `str` as a dtype was probably a bad idea in the first place, so I changed it to `object` which is a supported dtype in pandas, and behaves as expected.