### PR TITLE
add support for new nullable types from pandas 1.0

### DIFF
--- a/behave_pandas/column_types.py
+++ b/behave_pandas/column_types.py
@@ -165,16 +165,12 @@ class ObjectColumnParser(ColumnParser):
 
 VALID_BOOL_TYPES = {
     "bool": LegacyBooleanColumnParser(),
-    # new nullable type from pandas 1.0
-    "boolean": NullableBooleanColumnParser(),
 }
 
 VALID_INT_TYPES = {
     "int": LegacyIntegerColumnParser("int"),
     "int32": LegacyIntegerColumnParser("int32"),
     "int64": LegacyIntegerColumnParser("int64"),
-    # new nullable type from pandas 1.0
-    "Int64": NullableIntegerColumnParser("Int64"),
 }
 
 VALID_FLOAT_TYPES = {
@@ -189,10 +185,6 @@ VALID_DATETIME_TYPES = {
     "datetime64[ns]": DatetimeColumnParser(),
 }
 
-VALID_STRING_TYPES = {
-    "string": StringColumnParser(),
-}
-
 VALID_OBJECT_TYPES = {
     "object": ObjectColumnParser(),
     "str": LegacyStringColumnParser(),
@@ -201,11 +193,18 @@ VALID_OBJECT_TYPES = {
     "OrderedDict": OrderedDictColumnParser(),
 }
 
+# new nullable type from pandas 1.0
+VALID_NULLABLE_TYPES = {
+    "boolean": NullableBooleanColumnParser(),
+    "Int64": NullableIntegerColumnParser("Int64"),
+    "string": StringColumnParser(),
+}
+
 VALID_COLUMN_TYPES = {
     **VALID_BOOL_TYPES,
     **VALID_INT_TYPES,
     **VALID_FLOAT_TYPES,
     **VALID_DATETIME_TYPES,
-    **VALID_STRING_TYPES,
+    **VALID_NULLABLE_TYPES,
     **VALID_OBJECT_TYPES,
 }

--- a/behave_pandas/column_types.py
+++ b/behave_pandas/column_types.py
@@ -79,6 +79,9 @@ class LegacyIntegerColumnParser(ColumnParser):
 
 
 class NullableIntegerColumnParser(ColumnParser):
+    def __init__(self):
+        super().__init__("Int64")
+
     def parse_value(self, cell):
         if cell == "":
             return pd.NA
@@ -196,7 +199,7 @@ VALID_OBJECT_TYPES = {
 # new nullable type from pandas 1.0
 VALID_NULLABLE_TYPES = {
     "boolean": NullableBooleanColumnParser(),
-    "Int64": NullableIntegerColumnParser("Int64"),
+    "Int64": NullableIntegerColumnParser(),
     "string": StringColumnParser(),
 }
 

--- a/behave_pandas/printer.py
+++ b/behave_pandas/printer.py
@@ -5,7 +5,7 @@ from behave_pandas.column_types import (
     VALID_FLOAT_TYPES,
     VALID_DATETIME_TYPES,
     VALID_OBJECT_TYPES,
-)
+    VALID_NULLABLE_TYPES)
 
 
 def dataframe_to_table(df):
@@ -15,6 +15,7 @@ def dataframe_to_table(df):
     :return: str
     """
     to_format = df.reset_index()
+
     cols_with_potential_nones = to_format.select_dtypes("object").columns
     to_format.loc[:, cols_with_potential_nones] = to_format.loc[
         :, cols_with_potential_nones
@@ -31,6 +32,12 @@ def dataframe_to_table(df):
         if str(dtype) in VALID_DATETIME_TYPES.keys()
     ]
 
+    cols_with_potential_null_types = [
+        col
+        for col, dtype in to_format.dtypes.iteritems()
+        if str(dtype) in VALID_NULLABLE_TYPES.keys()
+    ]
+
     as_string = to_format.astype(str)
     as_string.loc[:, cols_with_potential_nans] = as_string.loc[
         :, cols_with_potential_nans
@@ -38,6 +45,9 @@ def dataframe_to_table(df):
     as_string.loc[:, cols_with_potential_nats] = as_string.loc[
         :, cols_with_potential_nats
     ].replace("NaT", "")
+    as_string.loc[:, cols_with_potential_null_types] = as_string.loc[
+        :, cols_with_potential_null_types
+    ].replace("<NA>", "")
 
     table_string_df = pd.concat(
         [to_format.dtypes.to_frame().T, to_format.columns.to_frame().T, as_string]

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+
+def before_scenario(context, scenario):
+    if should_skip_scenario_due_to_pandas_version(context, scenario):
+        scenario.skip()
+
+
+def should_skip_scenario_due_to_pandas_version(context, scenario):
+    """
+    Allow to skip scenario for a given pandas version by decorating it with @skip.pandasversion_comparison
+    ie @skip.pandas>, @skipApi>25, @skipApi<24, @skipApi>=25, @skipApi<=29
+    """
+    pandas_skip_tag = "skip.before.pandasv1"
+
+    if pandas_skip_tag in scenario.effective_tags:
+        if int(pd.__version__[0]) < 1:
+            return True
+    return False

--- a/features/environment.py
+++ b/features/environment.py
@@ -8,8 +8,8 @@ def before_scenario(context, scenario):
 
 def should_skip_scenario_due_to_pandas_version(context, scenario):
     """
-    Allow to skip scenario for a given pandas version by decorating it with @skip.pandasversion_comparison
-    ie @skip.pandas>, @skipApi>25, @skipApi<24, @skipApi>=25, @skipApi<=29
+    Allow to skip scenario for a given pandas version:
+    @skip.before.pandasv1.
     """
     pandas_skip_tag = "skip.before.pandasv1"
 

--- a/features/nullable_dtypes.feature
+++ b/features/nullable_dtypes.feature
@@ -1,3 +1,4 @@
+@skip.before.pandasv1
 Feature: dtype support for new nullable dtypes in pandas 1.0
 
   as a tester

--- a/features/nullable_dtypes.feature
+++ b/features/nullable_dtypes.feature
@@ -1,0 +1,31 @@
+Feature: dtype support for new nullable dtypes in pandas 1.0
+
+  as a tester
+  I want to be able to create column for all the new nullable dtypes supported by pandas v1.0 and above
+
+  Scenario: boolean dtype
+    Given a gherkin table as input
+      | boolean |
+      | True    |
+      | False   |
+      |         |
+    When converted to a data frame using 0 row as column names and 0 column as index
+    Then it matches a manually created data frame with all valid nullable boolean dtypes
+
+  Scenario: integer dtype
+    Given a gherkin table as input
+      | Int64 |
+      | 0     |
+      | 10    |
+      |       |
+    When converted to a data frame using 0 row as column names and 0 column as index
+    Then it matches a manually created data frame with all valid nullable integer dtypes
+
+  Scenario: string dtypes
+    Given a gherkin table as input
+      | string | string      |
+      | egg    | silly walks |
+      | spam   | ""          |
+      |        | dead parrot |
+    When converted to a data frame using 0 row as column names and 0 column as index
+    Then it matches a manually created data frame with all valid string dtypes

--- a/features/printer.feature
+++ b/features/printer.feature
@@ -38,3 +38,23 @@ Feature: Table printer
     | spam      | 4.1       |             | 2018-02-03     | {'a': 1}  |          |                          |                          |
     | bacon     | 5.2       | dead parrot |                | {'a': []} | [1]      | OrderedDict([('a', [])]) | OrderedDict([('a', [])]) |
     """
+
+  @skip.before.pandasv1
+  Scenario: round trip new nullable types from pandas v1.0
+    Given a gherkin table as input
+      | object    | boolean     | string      | Int64       |
+      | index_col | boolean_col | string_col  | integer_col |
+      | egg       |             | silly walks | 42          |
+      | spam      | False       |             | 23          |
+      | bacon     | True        | dead parrot |             |
+
+    When converted to a data frame using 1 row as column names and 1 column as index
+    And printed using data_frame_to_table
+    Then it prints a valid string copy pasteable into gherkin files
+    """
+    | object    | boolean     | string      | Int64       |
+    | index_col | boolean_col | string_col  | integer_col |
+    | egg       |             | silly walks | 42          |
+    | spam      | False       |             | 23          |
+    | bacon     | True        | dead parrot |             |
+    """

--- a/features/steps/nullable_dtypes_steps.py
+++ b/features/steps/nullable_dtypes_steps.py
@@ -1,0 +1,37 @@
+import datetime
+from collections import OrderedDict
+
+from behave import *
+from behave_pandas import table_to_dataframe
+
+import pandas as pd
+import pandas.testing as pdt
+import numpy as np
+
+use_step_matcher("parse")
+
+
+@then("it matches a manually created data frame with all valid nullable boolean dtypes")
+def step_impl(context):
+    all_dtypes_df = pd.concat(
+        [pd.Series([True, False, pd.NA], dtype="boolean")], axis=1
+    )
+    pdt.assert_frame_equal(all_dtypes_df, context.parsed)
+
+
+@then("it matches a manually created data frame with all valid nullable integer dtypes")
+def step_impl(context):
+    all_dtypes_df = pd.concat([pd.Series([0, 10, pd.NA], dtype="Int64"),], axis=1,)
+    pdt.assert_frame_equal(all_dtypes_df, context.parsed)
+
+
+@then("it matches a manually created data frame with all valid string dtypes")
+def step_impl(context):
+    all_dtypes_df = pd.concat(
+        [
+            pd.Series(["egg", "spam", pd.NA], dtype="string"),
+            pd.Series(["silly walks", "", "dead parrot"], dtype="string"),
+        ],
+        axis=1,
+    )
+    pdt.assert_frame_equal(all_dtypes_df, context.parsed)


### PR DESCRIPTION
This PR adds support for the new nullable types introduced in pandas 0.25 and 1.0: 
https://pandas.pydata.org/pandas-docs/stable/user_guide/integer_na.html?highlight=nullable
https://pandas.pydata.org/pandas-docs/stable/user_guide/boolean.html
https://pandas.pydata.org/pandas-docs/stable/user_guide/text.html#text-types

